### PR TITLE
proof of concept demo with iron-form

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -13,7 +13,10 @@
   ],
   "main": "google-recaptcha.html",
   "dependencies": {
-    "polymer": "Polymer/polymer#^1.0.0"
+    "iron-form": "PolymerElements/iron-form#^1.0.9",
+    "polymer": "Polymer/polymer#^1.0.0",
+    "iron-form-element-behavior": "PolymerElements/iron-form-element-behavior#~1.0.4",
+    "iron-validatable-behavior": "PolymerElements/iron-validatable-behavior#~1.0.4"
   },
   "devDependencies": {
     "web-component-tester": "*",

--- a/demo/index.html
+++ b/demo/index.html
@@ -18,6 +18,7 @@
   </style>
   <script src="../../webcomponentsjs/webcomponents-lite.min.js"></script>
   <link rel="import" href="../google-recaptcha.html">
+  <link rel="import" href="../iron-form/iron-form.html">
   <script type="text/javascript">
     window.addEventListener('WebComponentsReady', function(e) {
       var rec = document.querySelector('google-recaptcha');
@@ -40,11 +41,27 @@
 <body>
   <p>Default re-captcha</p>
   <google-recaptcha sitekey="6LdRcP4SAAAAAJ4Dq1gXcD9AyhzuG77iz7E2Dmu4"></google-recaptcha>
-  <p>Dark re-captcha</p>
-  <google-recaptcha theme="dark" sitekey="6LdRcP4SAAAAAJ4Dq1gXcD9AyhzuG77iz7E2Dmu4"></google-recaptcha>
-  <p>Audio re-captcha</p>
-  <google-recaptcha type="audio" sitekey="6LdRcP4SAAAAAJ4Dq1gXcD9AyhzuG77iz7E2Dmu4"></google-recaptcha>
+
   <p>Event message (working with the first captcha)</p>
   <p id="eventMessage"></p>
+
+  <hr>
+
+  <p>Dark re-captcha</p>
+  <google-recaptcha theme="dark" sitekey="6LdRcP4SAAAAAJ4Dq1gXcD9AyhzuG77iz7E2Dmu4"></google-recaptcha>
+
+  <hr>
+
+  <p>Audio re-captcha</p>
+  <google-recaptcha type="audio" sitekey="6LdRcP4SAAAAAJ4Dq1gXcD9AyhzuG77iz7E2Dmu4"></google-recaptcha>
+
+  <hr>
+
+  <form is="iron-form" style="outline: thin solid #ccc; padding: .5rem 2rem;">
+    <h2>Demo within an iron-form</h2>
+    <google-recaptcha required sitekey="6LdRcP4SAAAAAJ4Dq1gXcD9AyhzuG77iz7E2Dmu4"></google-recaptcha>
+    <button type="submit" >Submit</button>
+  </form>
+
 </body>
 </html>

--- a/demo/index.html
+++ b/demo/index.html
@@ -59,8 +59,7 @@
 
   <form is="iron-form" style="border: 1px solid #ccc; padding: 0 25px 25px;">
     <h2>Demo within an iron-form</h2>
-    <google-recaptcha required sitekey="6LdRcP4SAAAAAJ4Dq1gXcD9AyhzuG77iz7E2Dmu4"
-      style="display: inline-block; padding-top: 2px; padding-left: 2px;"></google-recaptcha>
+    <google-recaptcha sitekey="6LdRcP4SAAAAAJ4Dq1gXcD9AyhzuG77iz7E2Dmu4"></google-recaptcha>
     <div><button type="submit">Submit</button></div>
   </form>
 

--- a/demo/index.html
+++ b/demo/index.html
@@ -57,10 +57,11 @@
 
   <hr>
 
-  <form is="iron-form" style="outline: thin solid #ccc; padding: .5rem 2rem;">
+  <form is="iron-form" style="border: 1px solid #ccc; padding: 0 25px 25px;">
     <h2>Demo within an iron-form</h2>
-    <google-recaptcha required sitekey="6LdRcP4SAAAAAJ4Dq1gXcD9AyhzuG77iz7E2Dmu4"></google-recaptcha>
-    <button type="submit" >Submit</button>
+    <google-recaptcha required sitekey="6LdRcP4SAAAAAJ4Dq1gXcD9AyhzuG77iz7E2Dmu4"
+      style="display: inline-block; padding-top: 2px; padding-left: 2px;"></google-recaptcha>
+    <div><button type="submit">Submit</button></div>
   </form>
 
 </body>

--- a/google-recaptcha.html
+++ b/google-recaptcha.html
@@ -29,7 +29,8 @@ See https://developers.google.com/recaptcha
       display: block;
     }
     :host.invalid {
-      outline: 1px solid red;
+      border: 1px solid red;
+      border-radius: 3px;
     }
   </style>
   <template><content></content></template>

--- a/google-recaptcha.html
+++ b/google-recaptcha.html
@@ -24,7 +24,7 @@ See https://developers.google.com/recaptcha
 @demo demo/index.html
 -->
 <dom-module id="google-recaptcha">
-  <template class="foo">
+  <template>
     <style>
       :host {
         display: inline-block;

--- a/google-recaptcha.html
+++ b/google-recaptcha.html
@@ -4,6 +4,8 @@
  license that can be found in the LICENSE file.
 -->
 <link rel="import" href="../polymer/polymer.html">
+<link rel="import" href="../iron-form-element-behavior/iron-form-element-behavior.html">
+<link rel="import" href="../iron-validatable-behavior/iron-validatable-behavior.html">
 
 <!--
 Polymer element for Google reCAPTCHA
@@ -26,6 +28,9 @@ See https://developers.google.com/recaptcha
     :host {
       display: block;
     }
+    :host.invalid {
+      outline: 1px solid red;
+    }
   </style>
   <template><content></content></template>
 </dom-module>
@@ -42,6 +47,18 @@ See https://developers.google.com/recaptcha
       _delay:0,
       _containerId:'',
       _captchaId:'',
+
+      _invalid: true,
+
+      behaviors: [
+        Polymer.IronFormElementBehavior,
+        Polymer.IronValidatableBehavior
+      ],
+
+      _getValidity: function () {
+        this.toggleClass('invalid', this._invalid);
+        return !this._invalid;
+      },
 
       properties: {
         /**
@@ -95,10 +112,10 @@ See https://developers.google.com/recaptcha
       },
 
       observers: [
-        '_validate(theme, type, timeout)'
+        '_validateAttrs(theme, type, timeout)'
       ],
 
-      _validate:function () {
+      _validateAttrs: function () {
         if(this.theme!='dark' && this.theme!='light'){
           this.theme='light';
         }
@@ -217,6 +234,8 @@ See https://developers.google.com/recaptcha
        *  @param {String} response response to store
        */
       _responseHandler: function (response) {
+        this._invalid = false;
+        this.toggleClass('invalid', this._invalid);
         this.response=response;
         this.fire('captcha-response',{response:response});
       },
@@ -232,6 +251,8 @@ See https://developers.google.com/recaptcha
        * The `expiredHandler` method fires the captcha-expired event.
        */
       _expiredHandler: function () {
+        this._invalid = true;
+        this.toggleClass('invalid', this._invalid);
         this.fire('captcha-expired');
       }
     });

--- a/google-recaptcha.html
+++ b/google-recaptcha.html
@@ -24,16 +24,18 @@ See https://developers.google.com/recaptcha
 @demo demo/index.html
 -->
 <dom-module id="google-recaptcha">
-  <style>
-    :host {
-      display: block;
-    }
-    :host.invalid {
-      border: 1px solid red;
-      border-radius: 3px;
-    }
-  </style>
-  <template><content></content></template>
+  <template class="foo">
+    <style>
+      :host {
+        display: inline-block;
+        padding: 2px 0 0 2px;
+      }
+      :host[invalid]:not([pristine]) {
+        border: 1px solid red;
+        border-radius: 3px;
+      }
+    </style>
+  </template>
 </dom-module>
 
 <script>
@@ -49,19 +51,38 @@ See https://developers.google.com/recaptcha
       _containerId:'',
       _captchaId:'',
 
-      _invalid: true,
-
       behaviors: [
         Polymer.IronFormElementBehavior,
         Polymer.IronValidatableBehavior
       ],
 
       _getValidity: function () {
-        this.toggleClass('invalid', this._invalid);
-        return !this._invalid;
+        this.pristine = false;
+        return !this.invalid;
       },
 
       properties: {
+        /**
+         * Whether a captcha in an iron-form is a required input.
+         */
+        required: {
+          type: Boolean,
+          reflectToAttribute: true,
+          value: true
+        },
+
+        invalid: {
+          type: Boolean,
+          reflectToAttribute: true,
+          value: true
+        },
+
+        pristine: {
+          type: Boolean,
+          reflectToAttribute: true,
+          value: true
+        },
+
         /**
          * The total time (in milliseconds) to wait for API loading
          */
@@ -153,7 +174,6 @@ See https://developers.google.com/recaptcha
         return (S4()+S4()+"-"+S4()+"-"+S4()+"-"+S4()+"-"+S4()+S4()+S4());
       },
       ready: function () {
-
       },
       attached: function () {
         if(this.sitekey===''){
@@ -235,8 +255,7 @@ See https://developers.google.com/recaptcha
        *  @param {String} response response to store
        */
       _responseHandler: function (response) {
-        this._invalid = false;
-        this.toggleClass('invalid', this._invalid);
+        this.invalid = false;
         this.response=response;
         this.fire('captcha-response',{response:response});
       },
@@ -252,8 +271,7 @@ See https://developers.google.com/recaptcha
        * The `expiredHandler` method fires the captcha-expired event.
        */
       _expiredHandler: function () {
-        this._invalid = true;
-        this.toggleClass('invalid', this._invalid);
+        this.invalid = true;
         this.fire('captcha-expired');
       }
     });

--- a/google-recaptcha.html
+++ b/google-recaptcha.html
@@ -255,6 +255,7 @@ See https://developers.google.com/recaptcha
        *  @param {String} response response to store
        */
       _responseHandler: function (response) {
+        this.pristine = false;
         this.invalid = false;
         this.response=response;
         this.fire('captcha-response',{response:response});
@@ -271,6 +272,7 @@ See https://developers.google.com/recaptcha
        * The `expiredHandler` method fires the captcha-expired event.
        */
       _expiredHandler: function () {
+        this.pristine = false;
         this.invalid = true;
         this.fire('captcha-expired');
       }

--- a/google-recaptcha.html
+++ b/google-recaptcha.html
@@ -113,10 +113,10 @@ See https://developers.google.com/recaptcha
       },
 
       observers: [
-        '_validateAttrs(theme, type, timeout)'
+        '_checkOptions(theme, type, timeout)'
       ],
 
-      _validateAttrs: function () {
+      _checkOptions: function () {
         if(this.theme!='dark' && this.theme!='light'){
           this.theme='light';
         }


### PR DESCRIPTION
This is a first pass at demonstrating putting a required google-recaptcha element inside an iron-form. To accomplish this, I gave the google-recaptcha element the `Polymer.IronFormElementBehavior` and `Polymer.IronValidatableBehavior` behaviors and supporting logic.

This may more properly belong in a separate element just for iron-forms (e.g. `iron-form-recaptcha`) if you'd like to keep `google-recaptcha` agnostic to the form implementation it's included in, but it seems there should be a generic way for the `google-recaptcha` element to advertise its validity state to any containing form implementations. Polymer developers please advise, and I will be happy to help with taking this from proof of concept to whatever you envision offering.
